### PR TITLE
Improve build scripts to release independently 

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Build with Gradle
         env:
           GITHUB_TOKEN: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
         run: |
-          ./gradlew build
           ./gradlew publish

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -17,6 +17,7 @@ jobs:
           java-version: 1.8
       - name: Build with Gradle
         env:
+          GITHUB_TOKEN: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
         run: ./gradlew build
@@ -33,6 +34,7 @@ jobs:
           java-version: 1.8
       - name: Build with Gradle
         env:
+          GITHUB_TOKEN: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
         run: ./gradlew.bat build

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,8 +19,11 @@ jobs:
       - name: Publish artifact
         env:
           GITHUB_TOKEN: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
+          BALLERINA_CENTRAL_ACCESS_TOKEN: ${{ secrets.BALLERINA_CENTRAL_ACCESS_TOKEN }}
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
         run: |
           NEW_VERSION=$(echo "${GITHUB_REF}" | cut -d "/" -f3)
           echo "New version: ${NEW_VERSION}"
           echo "Github username: ${GITHUB_ACTOR}"
-          ./gradlew -Pversion=${NEW_VERSION} publish
+          ./gradlew -PpublishToCentral=true -Pversion=${NEW_VERSION} publish

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,6 +14,10 @@ jobs:
         with:
           java-version: 1.8
       - name: Build with Gradle
+        env:
+          GITHUB_TOKEN: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
         run: ./gradlew build
 
   windows-build:
@@ -27,4 +31,8 @@ jobs:
         with:
           java-version: 1.8
       - name: Build with Gradle
+        env:
+          GITHUB_TOKEN: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.BALLERINA_STDLIB_TOKEN }}
         run: ./gradlew.bat build

--- a/encoding-ballerina/build.gradle
+++ b/encoding-ballerina/build.gradle
@@ -75,15 +75,20 @@ task ballerinaBuild {
         ballerinaConfigFile.text = newConfig
 
         def distributionBinPath =  project.projectDir.absolutePath + "/build/target/extracted-distributions/jballerina-tools-zip/jballerina-tools-${ballerinaLangVersion}/bin"
+        def additionalBuildParams = ""
+
+        if (project.hasProperty("skipBallerinaTests")) {
+            additionalBuildParams = "--skip-tests"
+        }
 
         // Build and populate caches
         exec {
             workingDir project.projectDir
             environment "JAVA_OPTS", "-DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true"
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "$distributionBinPath/ballerina.bat build -c ${moduleName}"
+                commandLine 'cmd', '/c', "$distributionBinPath/ballerina.bat build ${additionalBuildParams} -c ${moduleName}"
             } else {
-                commandLine 'sh', '-c', "$distributionBinPath/ballerina build -c ${moduleName}"
+                commandLine 'sh', '-c', "$distributionBinPath/ballerina build ${additionalBuildParams} -c ${moduleName}"
             }
         }
         copy {


### PR DESCRIPTION
## Purpose
$subject

## Approach
- Add ballerina central access token to provide the functionality to make independent releases. So, developers can make independent releases, and those releases publish artifacts to GitHub packages and also push to ballerina central.
- Sometimes releases fail due to unexpected problems in the containerized environments(Jenkins). At that time we may need to skip the ballerina releases. To do that we introduce a Gradle parameter. When you enable `-PskipBallerinaTests=true`, you can build without skipping the ballerina test cases. For example:

```sh
./gradlew clean build -PskipBallerinaTests=true
```

